### PR TITLE
Expand SSML to full W3C useful subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,8 +318,12 @@ babelvox --ssml --text '<speak>Hello.<break time="500ms"/>World.</speak>' -o out
 | `<break time="500ms"/>` | Insert pause (maps to punctuation) |
 | `<break strength="strong"/>` | Insert pause by strength level |
 | `<sub alias="...">` | Replace text with alias |
-| `<say-as interpret-as="number\|date\|time\|telephone\|spell-out">` | Normalize to spoken form |
-| `<emphasis>`, `<prosody>`, `<phoneme>` | Parsed into annotations (best-effort prosody hints) |
+| `<say-as interpret-as="...">` | Normalize to spoken form (number, date, time, telephone, spell-out, fraction, unit, verbatim) |
+| `<emphasis level="strong">` | Apply emphasis (strong=CAPS, moderate=Title Case, reduced=lower) |
+| `<p>`, `<s>` | Paragraph/sentence boundaries with natural pauses |
+| `<voice name="steve">` | Speaker selection (maps to saved profiles, annotation for pipeline) |
+| `<mark name="..."/>` | Timing bookmark (annotation for timestamp tracking) |
+| `<prosody>`, `<phoneme>` | Parsed into annotations (best-effort prosody hints) |
 
 Onomatopoeia (boom, crash, sizzle, etc.) is detected and annotated for prosody emphasis.
 

--- a/src/babelvox/static/index.html
+++ b/src/babelvox/static/index.html
@@ -596,7 +596,12 @@ canvas.waveform {
           <button class="snippet-btn" onclick="insertSSML('date')">&lt;say-as date&gt;</button>
           <button class="snippet-btn" onclick="insertSSML('telephone')">&lt;say-as telephone&gt;</button>
           <button class="snippet-btn" onclick="insertSSML('spell')">&lt;say-as spell-out&gt;</button>
+          <button class="snippet-btn" onclick="insertSSML('fraction')">&lt;say-as fraction&gt;</button>
+          <button class="snippet-btn" onclick="insertSSML('unit')">&lt;say-as unit&gt;</button>
           <button class="snippet-btn" onclick="insertSSML('emphasis')">&lt;emphasis&gt;</button>
+          <button class="snippet-btn" onclick="insertSSML('voice')">&lt;voice&gt;</button>
+          <button class="snippet-btn" onclick="insertSSML('p')">&lt;p&gt;</button>
+          <button class="snippet-btn" onclick="insertSSML('mark')">&lt;mark&gt;</button>
           <button class="snippet-btn" onclick="insertSSML('template')">Full Template</button>
         </div>
       </div>
@@ -1014,14 +1019,20 @@ const SSML_SNIPPETS = {
   date: '<say-as interpret-as="date" format="mdy">03/20/2026</say-as>',
   telephone: '<say-as interpret-as="telephone">555-123-4567</say-as>',
   spell: '<say-as interpret-as="spell-out">NASA</say-as>',
-  emphasis: '<emphasis>important</emphasis>',
+  fraction: '<say-as interpret-as="fraction">3/4</say-as>',
+  unit: '<say-as interpret-as="unit">5kg</say-as>',
+  emphasis: '<emphasis level="strong">important</emphasis>',
+  voice: '<voice name="steve">Hello from Steve.</voice>',
+  p: '<p>This is a paragraph.</p>',
+  mark: '<mark name="section1"/>',
   template: `<speak>
-Hello, welcome to BabelVox.
+<p>Hello, welcome to BabelVox.</p>
+<p>The price is <say-as interpret-as="number">$4.50</say-as>.
 <break time="500ms"/>
-The price is <say-as interpret-as="number">$4.50</say-as>.
-<break time="300ms"/>
-Call us at <say-as interpret-as="telephone">555-123-4567</say-as>.
-<sub alias="World Wide Web">WWW</sub> is great.
+That is <say-as interpret-as="fraction">3/4</say-as> off!
+<emphasis level="strong">Amazing</emphasis> deal.</p>
+<p>Call us at <say-as interpret-as="telephone">555-123-4567</say-as>.
+<sub alias="World Wide Web">WWW</sub> is great.</p>
 </speak>`,
 };
 

--- a/src/babelvox/text/__init__.py
+++ b/src/babelvox/text/__init__.py
@@ -12,6 +12,7 @@ from babelvox.text.ssml import Annotation, looks_like_ssml, parse_ssml
 
 __all__ = [
     "preprocess_text",
+    "preprocess_text_with_annotations",
     "parse_ssml",
     "Annotation",
     "normalize_text",
@@ -38,12 +39,29 @@ def preprocess_text(text: str, language: str = "english",
     str
         Cleaned plain text ready for tokenization.
     """
+    result, _ = preprocess_text_with_annotations(text, language, is_ssml)
+    return result
+
+
+def preprocess_text_with_annotations(
+        text: str, language: str = "english",
+        is_ssml: bool = False) -> tuple[str, list[Annotation]]:
+    """Run the full text preprocessing pipeline, returning annotations.
+
+    Returns
+    -------
+    tuple[str, list[Annotation]]
+        Cleaned plain text and any SSML annotations (voice, prosody,
+        phoneme, mark) for downstream pipeline use.
+    """
+    annotations: list[Annotation] = []
+
     if is_ssml or looks_like_ssml(text):
         def _say_as_fn(inner, interpret_as, fmt):
             return normalize_say_as(inner, interpret_as, fmt, language)
 
-        text, _annotations = parse_ssml(text, normalizer_fn=_say_as_fn)
+        text, annotations = parse_ssml(text, normalizer_fn=_say_as_fn)
 
     text = normalize_text(text, language)
     text = normalize_punctuation(text)
-    return text
+    return text, annotations

--- a/src/babelvox/text/normalizer.py
+++ b/src/babelvox/text/normalizer.py
@@ -200,14 +200,38 @@ def normalize_letter_acronyms(text: str) -> str:
     return _LETTER_ACRONYM_RE.sub(_repl, text)
 
 
+_UNIT_NAMES = {
+    "kg": "kilogram", "g": "gram", "mg": "milligram",
+    "lb": "pound", "oz": "ounce",
+    "km": "kilometer", "m": "meter", "cm": "centimeter", "mm": "millimeter",
+    "mi": "mile", "ft": "foot", "in": "inch", "yd": "yard",
+    "l": "liter", "ml": "milliliter", "gal": "gallon",
+    "s": "second", "ms": "millisecond", "min": "minute", "hr": "hour",
+    "mph": "miles per hour", "kph": "kilometers per hour",
+    "kb": "kilobyte", "mb": "megabyte", "gb": "gigabyte", "tb": "terabyte",
+}
+_UNIT_PLURALS = {"foot": "feet", "inch": "inches"}
+_UNIT_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*([a-zA-Z]+)$")
+_FRACTION_RE = re.compile(r"^(\d+)/(\d+)$")
+
+_SIMPLE_FRACTIONS = {
+    (1, 2): "one half", (1, 3): "one third", (2, 3): "two thirds",
+    (1, 4): "one quarter", (3, 4): "three quarters",
+    (1, 5): "one fifth", (2, 5): "two fifths", (3, 5): "three fifths",
+    (4, 5): "four fifths", (1, 8): "one eighth", (3, 8): "three eighths",
+    (5, 8): "five eighths", (7, 8): "seven eighths",
+}
+
+
 def normalize_say_as(text: str, interpret_as: str, fmt: str = "",
                      language: str = "english") -> str:
     """Dispatcher for SSML <say-as> interpret-as values."""
     text = text.strip()
-    if interpret_as == "number" or interpret_as == "cardinal":
+    lang_code = _LANG_MAP.get(language.lower(), "en")
+
+    if interpret_as in ("number", "cardinal"):
         return normalize_numbers(text, language)
     if interpret_as == "ordinal":
-        lang_code = _LANG_MAP.get(language.lower(), "en")
         try:
             return _num2words_safe(int(text), lang=lang_code, to="ordinal")
         except ValueError:
@@ -218,8 +242,32 @@ def normalize_say_as(text: str, interpret_as: str, fmt: str = "",
         return normalize_times(text, language)
     if interpret_as == "telephone":
         return normalize_telephone(text)
-    if interpret_as == "characters" or interpret_as == "spell-out":
+    if interpret_as in ("characters", "spell-out", "verbatim"):
         return " ".join(text)
+    if interpret_as == "fraction":
+        m = _FRACTION_RE.match(text)
+        if m:
+            num, den = int(m.group(1)), int(m.group(2))
+            simple = _SIMPLE_FRACTIONS.get((num, den))
+            if simple:
+                return simple
+            num_w = _num2words_safe(num, lang=lang_code)
+            den_w = _num2words_safe(den, lang=lang_code, to="ordinal")
+            if num > 1:
+                den_w += "s"
+            return f"{num_w} {den_w}"
+        return text
+    if interpret_as == "unit":
+        m = _UNIT_RE.match(text)
+        if m:
+            number, unit = float(m.group(1)), m.group(2).lower()
+            num_w = _num2words_safe(int(number) if number == int(number) else number,
+                                    lang=lang_code)
+            unit_name = _UNIT_NAMES.get(unit, unit)
+            if number != 1:
+                unit_name = _UNIT_PLURALS.get(unit_name, unit_name + "s")
+            return f"{num_w} {unit_name}"
+        return text
     return text
 
 

--- a/src/babelvox/text/ssml.py
+++ b/src/babelvox/text/ssml.py
@@ -1,10 +1,11 @@
 """SSML (Speech Synthesis Markup Language) parser for BabelVox.
 
-Parses a subset of the W3C SSML spec:
-  <break>, <sub>, <say-as>, <emphasis>, <prosody>, <phoneme>
+Parses a useful subset of the W3C SSML 1.1 spec:
+  Immediate: <break>, <sub>, <say-as>, <emphasis>, <p>, <s>
+  Deferred:  <prosody>, <phoneme>, <voice>, <mark>
 
-Tags that affect inference (emphasis, prosody, phoneme) are parsed into
-Annotation objects but not actioned until Phase 2 (prosody control).
+Immediate tags modify text during parsing. Deferred tags create
+Annotation objects for the pipeline to consume downstream.
 """
 from __future__ import annotations
 
@@ -59,6 +60,18 @@ def _parse_break(elem: ET.Element) -> str:
     return strength_map.get(strength, ".")
 
 
+def _apply_emphasis(text: str, level: str) -> str:
+    """Apply emphasis capitalization to text."""
+    level = level.lower() if level else "moderate"
+    if level == "strong":
+        return text.upper()
+    if level == "moderate":
+        return text.title()
+    if level == "reduced":
+        return text.lower()
+    return text  # "none" or unknown
+
+
 def _walk(elem: ET.Element, text_parts: list[str],
           annotations: list[Annotation], normalizer_fn) -> None:
     """Recursively walk SSML element tree, building plain text + annotations."""
@@ -75,7 +88,6 @@ def _walk(elem: ET.Element, text_parts: list[str],
         if alias:
             text_parts.append(alias)
         else:
-            # No alias — keep original text
             if elem.text:
                 text_parts.append(elem.text)
         if elem.tail:
@@ -95,10 +107,49 @@ def _walk(elem: ET.Element, text_parts: list[str],
             text_parts.append(elem.tail)
         return
 
-    # Tags that produce annotations (deferred to Phase 2)
-    if tag in ("emphasis", "prosody", "phoneme"):
+    # <emphasis> — immediate: apply capitalization based on level
+    if tag == "emphasis":
+        inner_parts: list[str] = []
+        if elem.text:
+            inner_parts.append(elem.text)
+        for child in elem:
+            _walk(child, inner_parts, annotations, normalizer_fn)
+        inner_text = "".join(inner_parts)
+        level = elem.get("level", "moderate")
+        text_parts.append(_apply_emphasis(inner_text, level))
+        if elem.tail:
+            text_parts.append(elem.tail)
+        return
+
+    # <p> / <s> — paragraph/sentence boundaries with trailing pause
+    if tag in ("p", "s"):
+        if elem.text:
+            text_parts.append(elem.text)
+        for child in elem:
+            _walk(child, text_parts, annotations, normalizer_fn)
+        # Ensure sentence-ending punctuation for natural pause
+        current = "".join(text_parts)
+        if current and current[-1] not in ".!?":
+            text_parts.append(". ")
+        else:
+            text_parts.append(" ")
+        if elem.tail:
+            text_parts.append(elem.tail)
+        return
+
+    # <mark> — timing bookmark (self-closing)
+    if tag == "mark":
+        pos = sum(len(p) for p in text_parts)
+        name = elem.get("name", "")
+        annotations.append(Annotation(start=pos, end=pos,
+                                       type="mark", params={"name": name}))
+        if elem.tail:
+            text_parts.append(elem.tail)
+        return
+
+    # Tags that produce annotations (deferred to pipeline)
+    if tag in ("prosody", "phoneme", "voice"):
         start = sum(len(p) for p in text_parts)
-        # Process children to get inner text
         if elem.text:
             text_parts.append(elem.text)
         for child in elem:
@@ -126,7 +177,11 @@ def _walk(elem: ET.Element, text_parts: list[str],
 def looks_like_ssml(text: str) -> bool:
     """Heuristic check for SSML content."""
     stripped = text.strip()
-    return stripped.startswith("<speak") or "<break" in stripped or "<sub " in stripped
+    return (stripped.startswith("<speak")
+            or "<break" in stripped
+            or "<sub " in stripped
+            or "<voice" in stripped
+            or "<mark" in stripped)
 
 
 def parse_ssml(text: str, normalizer_fn=None) -> tuple[str, list[Annotation]]:

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -172,6 +172,38 @@ class TestNormalizeSayAs:
         result = normalize_say_as("hello", "unknown_type")
         assert result == "hello"
 
+    def test_verbatim(self):
+        result = normalize_say_as("ABC", "verbatim")
+        assert result == "A B C"
+
+    def test_fraction_half(self):
+        result = normalize_say_as("1/2", "fraction")
+        assert result == "one half"
+
+    def test_fraction_three_quarters(self):
+        result = normalize_say_as("3/4", "fraction")
+        assert result == "three quarters"
+
+    def test_fraction_generic(self):
+        result = normalize_say_as("2/7", "fraction")
+        assert "two" in result
+        assert "seventh" in result
+
+    def test_unit_kg(self):
+        result = normalize_say_as("5kg", "unit")
+        assert "five" in result
+        assert "kilogram" in result
+
+    def test_unit_singular(self):
+        result = normalize_say_as("1m", "unit")
+        assert "one" in result
+        assert "meter" in result
+        assert "meters" not in result
+
+    def test_unit_unknown_suffix(self):
+        result = normalize_say_as("10xyz", "unit")
+        assert "ten" in result
+
 
 class TestNormalizeTextPipeline:
     def test_combined(self):

--- a/tests/test_ssml.py
+++ b/tests/test_ssml.py
@@ -13,11 +13,16 @@ class TestLooksLikeSSML:
     def test_sub_tag(self):
         assert looks_like_ssml("The <sub alias='World Wide Web'>WWW</sub>")
 
+    def test_voice_tag(self):
+        assert looks_like_ssml("<voice name='steve'>Hello</voice>")
+
+    def test_mark_tag(self):
+        assert looks_like_ssml("Hello <mark name='x'/> world")
+
     def test_plain_text(self):
         assert not looks_like_ssml("Hello world")
 
     def test_angle_brackets_in_math(self):
-        # < in math context shouldn't trigger
         assert not looks_like_ssml("x < 5 and y > 3")
 
 
@@ -98,15 +103,98 @@ class TestSayAs:
         assert "555-1234" in text
 
 
-class TestAnnotations:
-    def test_emphasis_creates_annotation(self):
+# ── Emphasis (immediate — applies capitalization) ─────────────────────
+
+class TestEmphasis:
+    def test_strong_capitalizes(self):
         ssml = "<speak>This is <emphasis level='strong'>important</emphasis> text</speak>"
         text, annotations = parse_ssml(ssml)
-        assert "important" in text
-        assert len(annotations) == 1
-        assert annotations[0].type == "emphasis"
-        assert annotations[0].params.get("level") == "strong"
+        assert "IMPORTANT" in text
+        assert len(annotations) == 0  # immediate, not deferred
 
+    def test_moderate_titlecases(self):
+        ssml = "<speak><emphasis level='moderate'>hello world</emphasis></speak>"
+        text, _ = parse_ssml(ssml)
+        assert "Hello World" in text
+
+    def test_reduced_lowercases(self):
+        ssml = "<speak><emphasis level='reduced'>HELLO</emphasis></speak>"
+        text, _ = parse_ssml(ssml)
+        assert "hello" in text
+
+    def test_none_unchanged(self):
+        ssml = "<speak><emphasis level='none'>Hello</emphasis></speak>"
+        text, _ = parse_ssml(ssml)
+        assert "Hello" in text
+
+    def test_default_is_moderate(self):
+        ssml = "<speak><emphasis>hello world</emphasis></speak>"
+        text, _ = parse_ssml(ssml)
+        assert "Hello World" in text
+
+
+# ── Paragraph and sentence markers ───────────────────────────────────
+
+class TestParagraphSentence:
+    def test_p_adds_period(self):
+        ssml = "<speak><p>First paragraph</p><p>Second paragraph</p></speak>"
+        text, _ = parse_ssml(ssml)
+        assert ". " in text or "." in text
+        assert "First paragraph" in text
+        assert "Second paragraph" in text
+
+    def test_s_adds_period(self):
+        ssml = "<speak><s>First sentence</s><s>Second sentence</s></speak>"
+        text, _ = parse_ssml(ssml)
+        assert ". " in text or "." in text
+
+    def test_p_preserves_existing_punctuation(self):
+        ssml = "<speak><p>Already has a period.</p><p>Next</p></speak>"
+        text, _ = parse_ssml(ssml)
+        # Should not double-punctuate
+        assert ".." not in text
+
+
+# ── Voice tag ────────────────────────────────────────────────────────
+
+class TestVoice:
+    def test_voice_creates_annotation(self):
+        ssml = "<speak><voice name='steve'>Hello from Steve</voice></speak>"
+        text, annotations = parse_ssml(ssml)
+        assert "Hello from Steve" in text
+        assert len(annotations) == 1
+        assert annotations[0].type == "voice"
+        assert annotations[0].params.get("name") == "steve"
+
+    def test_voice_span_positions(self):
+        ssml = "<speak>Intro <voice name='lou'>Lou speaks</voice> outro</speak>"
+        text, annotations = parse_ssml(ssml)
+        assert annotations[0].start == 6  # after "Intro "
+        assert text[annotations[0].start:annotations[0].end] == "Lou speaks"
+
+
+# ── Mark tag ─────────────────────────────────────────────────────────
+
+class TestMark:
+    def test_mark_creates_annotation(self):
+        ssml = "<speak>Hello <mark name='mid'/>world</speak>"
+        text, annotations = parse_ssml(ssml)
+        assert text == "Hello world"
+        assert len(annotations) == 1
+        assert annotations[0].type == "mark"
+        assert annotations[0].params["name"] == "mid"
+
+    def test_mark_position(self):
+        ssml = "<speak>AB<mark name='x'/>CD</speak>"
+        text, annotations = parse_ssml(ssml)
+        assert text == "ABCD"
+        assert annotations[0].start == 2
+        assert annotations[0].end == 2  # zero-width
+
+
+# ── Prosody and phoneme (deferred annotations) ───────────────────────
+
+class TestDeferredAnnotations:
     def test_prosody_creates_annotation(self):
         ssml = "<speak><prosody rate='fast' pitch='+2st'>Quick speech</prosody></speak>"
         text, annotations = parse_ssml(ssml)
@@ -114,27 +202,28 @@ class TestAnnotations:
         assert len(annotations) == 1
         assert annotations[0].type == "prosody"
         assert annotations[0].params.get("rate") == "fast"
-        assert annotations[0].params.get("pitch") == "+2st"
 
     def test_phoneme_creates_annotation(self):
-        ssml = "<speak>I say <phoneme ph='təˈmeɪtoʊ'>tomato</phoneme></speak>"
+        ssml = ("<speak>I say <phoneme ph='t&#x259;&#x2C8;me&#x26A;"
+                "to&#x28A;'>tomato</phoneme></speak>")
         text, annotations = parse_ssml(ssml)
         assert "tomato" in text
         assert len(annotations) == 1
         assert annotations[0].type == "phoneme"
 
     def test_annotation_spans_correct(self):
-        ssml = "<speak>AB<emphasis>CD</emphasis>EF</speak>"
+        ssml = "<speak>AB<prosody rate='fast'>CD</prosody>EF</speak>"
         text, annotations = parse_ssml(ssml)
         assert text == "ABCDEF"
         assert annotations[0].start == 2
         assert annotations[0].end == 4
 
     def test_nested_elements(self):
-        ssml = "<speak><prosody rate='slow'><emphasis>word</emphasis></prosody></speak>"
+        ssml = ("<speak><prosody rate='slow'>"
+                "<emphasis level='strong'>word</emphasis></prosody></speak>")
         text, annotations = parse_ssml(ssml)
-        assert "word" in text
-        assert len(annotations) == 2  # one for prosody, one for emphasis
+        assert "WORD" in text
+        assert len(annotations) == 1  # only prosody is deferred; emphasis is immediate
 
 
 class TestMalformedSSML:


### PR DESCRIPTION
## Summary

- Wire up `<emphasis>` tag (was parsed but unused) — now applies capitalization based on level
- Add `<p>` / `<s>` paragraph/sentence boundary tags with natural pauses
- Add `<voice name="...">` for speaker selection annotations
- Add `<mark name="..."/>` for timing bookmarks
- Expand `<say-as>` with fraction, unit, and verbatim types
- Add `preprocess_text_with_annotations()` API for downstream annotation use
- Update web UI with new SSML snippet buttons

## Test plan

- [x] All 244 tests pass (`pytest tests/`)
- [x] Ruff lint clean (`ruff check src/ tests/`)
- [ ] Manual: verify `<emphasis level="strong">hello</emphasis>` produces "HELLO"
- [ ] Manual: verify `<say-as interpret-as="fraction">3/4</say-as>` produces "three quarters"
- [ ] Manual: web UI new snippet buttons insert correct SSML